### PR TITLE
Change miner dashboard path

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -110,7 +110,7 @@ const AppContent = () => {
           <Route exact strict component={StatisticsPage} path="/statistics" />
           <Route exact strict component={FaqPage} path="/faq" />
           <Route exact strict component={MinersPage} path="/miners" />
-          <Route component={MinerDashboardPage} path="/miners/:coin/:address" />
+          <Route component={MinerDashboardPage} path="/miner/:coin/:address" />
           <Route exact strict component={BlocksPage} path="/blocks" />
           <Route exact strict component={SupportPage} path="/support" />
           <Route

--- a/src/components/LinkMiner.tsx
+++ b/src/components/LinkMiner.tsx
@@ -14,7 +14,7 @@ export const LinkMiner: React.FC<{
   chars?: number;
 }> = ({ address, coin, chars }) => {
   return (
-    <L to={{ pathname: `/miners/${coin}/${address}` }}>
+    <L to={{ pathname: `/miner/${coin}/${address}` }}>
       {stringUtils.shortenString(address, chars)}
     </L>
   );

--- a/src/components/SearchAddressBar/SearchAddressBar.tsx
+++ b/src/components/SearchAddressBar/SearchAddressBar.tsx
@@ -105,7 +105,7 @@ export const SearchAddressBar: React.FC<{ showResult?: boolean }> = ({
         .then((res) => {
           if (res) {
             saveAddressToCache(res, address);
-            history.push(`/miners/${res}/${address}`);
+            history.push(`/miner/${res}/${address}`);
           } else {
             alert(
               'Specified address was not found in our system. Try waiting some time if you are already mining.'

--- a/src/components/SearchAddressBar/SearchAddressCachedResult.tsx
+++ b/src/components/SearchAddressBar/SearchAddressCachedResult.tsx
@@ -50,7 +50,7 @@ export const SearchAddressCachedResult: React.FC<{ isOpen?: boolean }> = ({
     <>
       {data.map((item) => (
         <HistoryItem
-          to={`/miners/${item.coin}/${item.address}`}
+          to={`/miner/${item.coin}/${item.address}`}
           key={item.address}
         >
           <Address>{item.address}</Address>


### PR DESCRIPTION
This PR changes the miner dashboard URL from `/miners/:coin/:address` to `/miner/:coin/:address`. This is required to be compatible with internal systems on Flexpool that were written to utilize the second version on the path.