### PR TITLE
Add current gas limits to miner dashboard

### DIFF
--- a/src/hooks/useFeePayoutDetails.tsx
+++ b/src/hooks/useFeePayoutDetails.tsx
@@ -1,0 +1,23 @@
+import { useActiveCoinTicker } from 'src/rdx/localSettings/localSettings.hooks';
+
+const feePayoutLimitDetails = {
+  eth: {
+    unit: 'Gwei',
+    title: 'Gas Price',
+    multiplier: 1000000000,
+  },
+};
+
+export const useFeePayoutLimitDetails = (coin?: string) => {
+  const globalCoinTicker = useActiveCoinTicker();
+  const activeCoinTicker = coin || globalCoinTicker;
+
+  if (!activeCoinTicker) {
+    return null;
+  }
+
+  if (activeCoinTicker in feePayoutLimitDetails) {
+    return feePayoutLimitDetails[activeCoinTicker as keyof typeof feePayoutLimitDetails];
+  }
+  return null;
+};

--- a/src/pages/MinerDashboard/Header/MinerDetails.tsx
+++ b/src/pages/MinerDashboard/Header/MinerDetails.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Card } from 'src/components/layout/Card';
 import { Skeleton } from 'src/components/layout/Skeleton';
 import { useActiveCoinTickerDisplayValue } from 'src/hooks/useDisplayReward';
+import { useFeePayoutLimitDetails } from 'src/hooks/useFeePayoutDetails';
+import { useActiveCoinTicker } from 'src/rdx/localSettings/localSettings.hooks';
 import { useReduxState } from 'src/rdx/useReduxState';
 import { ApiPoolCoin } from 'src/types/PoolCoin.types';
 import { dateUtils } from 'src/utils/date.utils';
@@ -69,6 +71,7 @@ export const MinerDetails: React.FC<{
 }> = ({ coin }) => {
   const minerDetailsState = useReduxState('minerDetails');
   const settings = minerDetailsState.data;
+  const activeCoinTicker = useActiveCoinTicker();
 
   // const rank = React.useMemo(() => {
   //   if (settings) {
@@ -79,6 +82,8 @@ export const MinerDetails: React.FC<{
   // }, [settings]);
 
   const payoutLimit = useActiveCoinTickerDisplayValue(settings?.payoutLimit);
+  const feeDetails = useFeePayoutLimitDetails(activeCoinTicker);
+  const maxFeePrice = settings?.maxFeePrice;
 
   return (
     <Card paddingShort>
@@ -110,6 +115,13 @@ export const MinerDetails: React.FC<{
           <div>Payout Limit:&nbsp;</div>
           <div>{settings && coin ? payoutLimit : <Skeleton width={40} />}</div>
         </Item>
+        {
+        (maxFeePrice !== undefined && maxFeePrice > 0) ? (
+        <Item>
+          <div>Gas Limit:&nbsp;</div>
+          <div>{maxFeePrice}{' '}{feeDetails?.unit}</div>
+        </Item>) : (null)
+        }
         <Item>
           <div>Joined:&nbsp;</div>
           <div>

--- a/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
+++ b/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
@@ -12,25 +12,11 @@ import {
   useActiveCoinTicker,
   useCounterTicker,
 } from 'src/rdx/localSettings/localSettings.hooks';
+import { useFeePayoutLimitDetails } from 'src/hooks/useFeePayoutDetails';
 import { minerDetailsUpdatePayoutSettings } from 'src/rdx/minerDetails/minerDetails.actions';
 import { useReduxState } from 'src/rdx/useReduxState';
 import { getDisplayCounterTickerValue } from 'src/utils/currencyValue';
 import * as yup from 'yup';
-
-const feePayoutLimitDetails = {
-  eth: {
-    unit: 'Gwei',
-    title: 'Gas Price',
-    multiplier: 1000000000,
-  },
-};
-
-const getFeePayoutLimitDetails = (coin: string) => {
-  if (coin in feePayoutLimitDetails) {
-    return feePayoutLimitDetails[coin as keyof typeof feePayoutLimitDetails];
-  }
-  return null;
-};
 
 export const PayoutSettings: React.FC = () => {
   const activeCoinTicker = useActiveCoinTicker();
@@ -43,7 +29,7 @@ export const PayoutSettings: React.FC = () => {
     params: { address },
   } = useRouteMatch<{ address: string; coin: string }>();
 
-  const feeDetails = getFeePayoutLimitDetails(activeCoinTicker);
+  const feeDetails = useFeePayoutLimitDetails(activeCoinTicker);
 
   if (
     !minerSettings.data ||


### PR DESCRIPTION
Resolves [https://github.com/flexpool/frontend/issues/44](https://github.com/flexpool/frontend/issues/44).

If a Gas Limit is not set in the Payout Settings no "Gas Limit" info will be shown on the miner dashboard. Attached examples.

![Screenshot from 2021-04-17 04-18-40](https://user-images.githubusercontent.com/18224637/115109720-b775d280-9f34-11eb-905b-41ec709f4b38.png)
![Screenshot from 2021-04-17 04-19-12](https://user-images.githubusercontent.com/18224637/115109721-b80e6900-9f34-11eb-91ae-357c20032e8e.png)

