### PR TITLE
"90% of MEV Bonus" instead of "+90% MEV Bonus"

### DIFF
--- a/src/pages/Home/CoinEarnings.tsx
+++ b/src/pages/Home/CoinEarnings.tsx
@@ -195,7 +195,7 @@ const CoinEarningsItem: React.FC<{ data?: ApiPoolCoinFull }> = ({ data }) => {
             <p>
               0.5% Pool Fee
               <br />
-              90% MEV Bonus
+              90% of MEV Bonus
             </p>
           </PoolDetails>
         )}

--- a/src/pages/Home/CoinEarnings.tsx
+++ b/src/pages/Home/CoinEarnings.tsx
@@ -195,7 +195,7 @@ const CoinEarningsItem: React.FC<{ data?: ApiPoolCoinFull }> = ({ data }) => {
             <p>
               0.5% Pool Fee
               <br />
-              +90% MEV Bonus
+              90% MEV Bonus
             </p>
           </PoolDetails>
         )}


### PR DESCRIPTION
#96 

<img width="1440" alt="Screen Shot 2021-04-18 at 00 50 56" src="https://user-images.githubusercontent.com/52366220/115133655-4ab81200-9fe0-11eb-8bed-c3f6fc0bc982.png">

