### PR TITLE
Miner page updates

### DIFF
--- a/src/pages/MinerDashboard/Header/MinerDetails.tsx
+++ b/src/pages/MinerDashboard/Header/MinerDetails.tsx
@@ -9,36 +9,6 @@ import { ApiPoolCoin } from 'src/types/PoolCoin.types';
 import { dateUtils } from 'src/utils/date.utils';
 import styled from 'styled-components';
 
-// type MinerRank = 'freeloader' | 'loyalminer' | 'vip' | 'mvp';
-// const getRankColor = (rank: MinerRank) => {
-//   switch (rank) {
-//     case 'freeloader':
-//       return 'var(--text-primary)';
-//     case 'loyalminer':
-//       return 'var(--success)';
-//     case 'vip':
-//       return 'var(--secondary)';
-//     case 'mvp':
-//       return 'var(--primary)';
-//   }
-// };
-
-// const Rank = styled.span<{
-//   rank: MinerRank;
-// }>`
-//   ${(p) => `
-//     color: ${getRankColor(p.rank)}
-//   `}
-// `;
-
-// const getRank = (value: number): [string, MinerRank] => {
-//   const donation = value * 100;
-//   if (donation === 0) return ['Freeloader', 'freeloader'];
-//   else if (donation > 0 && donation <= 1) return ['Loyal Miner', 'loyalminer'];
-//   else if (donation > 1 && donation < 5) return ['VIP', 'vip'];
-//   else return ['MVP', 'mvp'];
-// };
-
 const Item = styled.div`
   display: flex;
   font-weight: 600;
@@ -73,14 +43,6 @@ export const MinerDetails: React.FC<{
   const settings = minerDetailsState.data;
   const activeCoinTicker = useActiveCoinTicker();
 
-  // const rank = React.useMemo(() => {
-  //   if (settings) {
-  //     return getRank(settings.poolDonation);
-  //   }
-
-  //   return null;
-  // }, [settings]);
-
   const payoutLimit = useActiveCoinTickerDisplayValue(settings?.payoutLimit);
   const feeDetails = useFeePayoutLimitDetails(activeCoinTicker);
   const maxFeePrice = settings?.maxFeePrice;
@@ -88,50 +50,31 @@ export const MinerDetails: React.FC<{
   return (
     <Card paddingShort>
       <Content>
-        {/* <Item>
-          <div>Rank:&nbsp;</div>
-          <div>
-            {rank ? (
-              <Rank rank={rank[1]}>{rank[0]}</Rank>
-            ) : (
-              <Skeleton width={80} />
-            )}
-          </div>
-        </Item>
-        <Item>
-          <div>Pool Donation:&nbsp;</div>
-          <div>
-            {settings ? (
-              settings.poolDonation * 100
-            ) : (
-              <>
-                <Skeleton width={40} />{' '}
-              </>
-            )}
-            %
-          </div>
-        </Item> */}
         <Item>
           <div>Payout Limit:&nbsp;</div>
           <div>{settings && coin ? payoutLimit : <Skeleton width={40} />}</div>
         </Item>
-        {
-        (maxFeePrice !== undefined && maxFeePrice > 0) ? (
-        <Item>
-          <div>Gas Limit:&nbsp;</div>
-          <div>{maxFeePrice}{' '}{feeDetails?.unit}</div>
-        </Item>) : (null)
-        }
-        <Item>
-          <div>Joined:&nbsp;</div>
-          <div>
-            {settings ? (
-              <>{dateUtils.formatDistance(settings.firstJoined * 1000)}</>
-            ) : (
-              <Skeleton width={50} />
-            )}
-          </div>
-        </Item>
+        {maxFeePrice !== undefined && maxFeePrice > 0 ? (
+          <Item>
+            <div>Gas Limit:&nbsp;</div>
+            <div>
+              {maxFeePrice} {feeDetails?.unit}
+            </div>
+          </Item>
+        ) : null}
+        {settings &&
+          !!settings.firstJoined && ( // will be hidden if unix timestamp is zero
+            <Item>
+              <div>Joined:&nbsp;</div>
+              <div>
+                {settings ? (
+                  <>{dateUtils.formatDistance(settings.firstJoined * 1000)}</>
+                ) : (
+                  <Skeleton width={50} />
+                )}
+              </div>
+            </Item>
+          )}
       </Content>
     </Card>
   );

--- a/src/pages/MinerDashboard/Header/MinerDetails.tsx
+++ b/src/pages/MinerDashboard/Header/MinerDetails.tsx
@@ -42,7 +42,6 @@ export const MinerDetails: React.FC<{
   const minerDetailsState = useReduxState('minerDetails');
   const settings = minerDetailsState.data;
   const activeCoinTicker = useActiveCoinTicker();
-
   const payoutLimit = useActiveCoinTickerDisplayValue(settings?.payoutLimit);
   const feeDetails = useFeePayoutLimitDetails(activeCoinTicker);
   const maxFeePrice = settings?.maxFeePrice;

--- a/src/pages/MinerDashboard/Rewards/Rewards.chart.tsx
+++ b/src/pages/MinerDashboard/Rewards/Rewards.chart.tsx
@@ -43,14 +43,18 @@ const RewardsChart: React.FC<{
     rewardsChart.responsive.useDefault = false;
     rewardsChart.responsive.rules.push(responsiveRule);
     rewardsChart.colors.list = [color('#0069ff')];
-    const rewardsChartData = rewards.map((item) => ({
-      date: new Date(item.timestamp * 1000),
-      totalRewards: item.totalRewards / Math.pow(10, coin.decimalPlaces),
-      countervaluedRewards: getDisplayCounterTickerValue(
-        (item.totalRewards / Math.pow(10, coin.decimalPlaces)) * counterPrice,
-        counterTicker
-      ),
-    }));
+    const rewardsChartData = rewards.map((item) => {
+      return {
+        date: new Date(
+          item.timestamp * 1000 + new Date().getTimezoneOffset() * 60 * 1000
+        ),
+        totalRewards: item.totalRewards / Math.pow(10, coin.decimalPlaces),
+        countervaluedRewards: getDisplayCounterTickerValue(
+          (item.totalRewards / Math.pow(10, coin.decimalPlaces)) * counterPrice,
+          counterTicker
+        ),
+      };
+    });
 
     rewardsChart.data = rewardsChartData.reverse();
 

--- a/src/pages/MinerDashboard/Stats/MinerStats.chart.tsx
+++ b/src/pages/MinerDashboard/Stats/MinerStats.chart.tsx
@@ -242,7 +242,9 @@ export const StatsChart: React.FC<{
             'https://static.flexpool.io/assets/website-illustrations/stats.svg'
           }
           title={'Not enough data'}
-          description={"It looks like you haven't submitted any valid share"}
+          description={
+            "We don't have enough data to show charts. If your workers are already mining, please allow up to 10 minutes for the data to be processed."
+          }
         />
       )}
     </>

--- a/src/pages/MinerDashboard/Stats/Stats.section.tsx
+++ b/src/pages/MinerDashboard/Stats/Stats.section.tsx
@@ -63,7 +63,7 @@ export const MinerStats = () => {
               totalShares,
               data?.validShares
             )}
-            value={formatSi(data?.validShares)}
+            value={formatSi(data?.validShares, '', { shortenAbove: 100000 })}
           />
           <StatItem
             title={getDisplayPercentage(
@@ -71,7 +71,7 @@ export const MinerStats = () => {
               totalShares,
               data?.staleShares
             )}
-            value={formatSi(data?.staleShares)}
+            value={formatSi(data?.staleShares, '', { shortenAbove: 100000 })}
           />
           <StatItem
             title={getDisplayPercentage(
@@ -79,7 +79,7 @@ export const MinerStats = () => {
               totalShares,
               data?.invalidShares
             )}
-            value={formatSi(data?.invalidShares)}
+            value={formatSi(data?.invalidShares, '', { shortenAbove: 100000 })}
           />
         </StatItemGrid>
       </Card>

--- a/src/pages/Miners/TopMiners.section.tsx
+++ b/src/pages/Miners/TopMiners.section.tsx
@@ -5,13 +5,13 @@ import DynamicList, {
 import { LinkMiner } from 'src/components/LinkMiner';
 import { useActiveCoinTicker } from 'src/rdx/localSettings/localSettings.hooks';
 import { formatSi } from 'src/utils/si.utils';
-import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
 import { useActiveCoinTickerDisplayValue } from 'src/hooks/useDisplayReward';
 import { useReduxState } from 'src/rdx/useReduxState';
 import { useDispatch } from 'react-redux';
 import { topMinersGet } from 'src/rdx/topMiners/topMiners.actions';
 import { Mono, Ws } from 'src/components/Typo/Typo';
 import { ApiTopMiner } from 'src/types/TopMiner.types';
+import { dateUtils } from 'src/utils/date.utils';
 
 const topMinersCol: DynamicListColumn<ApiTopMiner, { coinTicker: string }>[] = [
   {
@@ -65,7 +65,7 @@ const topMinersCol: DynamicListColumn<ApiTopMiner, { coinTicker: string }>[] = [
     title: 'Joined',
     skeletonWidth: 120,
     Component: ({ data }) => {
-      return <Ws>{formatDistanceToNowStrict(data.firstJoined * 1000)} ago</Ws>;
+      return <Ws>{dateUtils.formatDistance(data.firstJoined * 1000)}</Ws>;
     },
   },
 ];

--- a/src/utils/si.utils.ts
+++ b/src/utils/si.utils.ts
@@ -1,13 +1,34 @@
 const siSymbols = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
 
-export const formatSi = (value?: number, unit: string = '', decimals = 1) => {
+export const formatSi = (
+  value?: number,
+  unit: string = '',
+  opts?: {
+    decimals?: number;
+    /**
+     * default is 1000
+     * 1000: 23402 => 23.4 k, 1504 => 1.4 k
+     * 10000: 23402 => 23.4 k, 1504 => 1,504
+     * 100000: 23402 => 23,402, 1504 => 1,504
+     */
+    shortenAbove?: number;
+  }
+) => {
+  const options = {
+    decimals: 1,
+    shortenAbove: 1000,
+    ...opts,
+  };
+
+  let decimals = options.decimals;
+
   if (typeof value === 'undefined') {
     return null;
   }
 
   var siN = 0;
 
-  while (value >= 1000) {
+  while (value >= options.shortenAbove) {
     if (siN >= siSymbols.length) {
       break;
     }
@@ -17,7 +38,7 @@ export const formatSi = (value?: number, unit: string = '', decimals = 1) => {
 
   if (value < 10 && decimals === 1) decimals = 2;
 
-  return `${
+  return `${Intl.NumberFormat().format(
     Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals)
-  } ${siSymbols[siN]}${unit}`;
+  )} ${siSymbols[siN]}${unit}`;
 };


### PR DESCRIPTION
displays full number if short enough instead of k/m

![Screen Shot 2021-04-19 at 20 23 13](https://user-images.githubusercontent.com/15802823/115221552-23cb1e80-a14d-11eb-8660-b476651a5f16.png)
![Screen Shot 2021-04-19 at 20 22 31](https://user-images.githubusercontent.com/15802823/115221553-2463b500-a14d-11eb-9726-40d4abc63ec2.png)

hides "joined" in the header if timestamp by api is 0