### PR TITLE
Fixed doubled words in payment tooltip

### DIFF
--- a/src/pages/MinerDashboard/Header/Stats.tsx
+++ b/src/pages/MinerDashboard/Header/Stats.tsx
@@ -107,7 +107,7 @@ const BalanceProgressBar: React.FC<{
             <PayoutNumber>
               {dateUtils.formatDistance(
                 addSeconds(new Date(), payoutInSeconds)
-              )}
+              ).toString().substring(3)}
             </PayoutNumber>
             .
           </PayoutText>

--- a/src/pages/MinerDashboard/Header/Stats.tsx
+++ b/src/pages/MinerDashboard/Header/Stats.tsx
@@ -103,11 +103,11 @@ const BalanceProgressBar: React.FC<{
         </PayoutText>
         {payoutInSeconds && payoutInSeconds > 0 ? (
           <PayoutText>
-            The limit will be reached in{' '}
+            The limit will be reached{' '}
             <PayoutNumber>
               {dateUtils.formatDistance(
                 addSeconds(new Date(), payoutInSeconds)
-              ).toString().substring(3)}
+              )}
             </PayoutNumber>
             .
           </PayoutText>


### PR DESCRIPTION
Was
![image](https://user-images.githubusercontent.com/64182766/115243880-ba580980-a166-11eb-8625-1aaf9c11e51a.png)

Fixed
![image](https://user-images.githubusercontent.com/64182766/115243922-c5129e80-a166-11eb-8117-024dd7da6509.png)
