### PR TITLE
Remove preload of image asset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -68,7 +68,6 @@
     <link ref="preconnect" href="https://js.intercomcdn.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://xtwj9bs7n2j9.statuspage.io" />
-    <link rel="preload" as="image" href="/illustrations/world_map_dots.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 


### PR DESCRIPTION
removing preload of image asset as on some systems this was throwing an error below:
![image](https://user-images.githubusercontent.com/15802823/115587071-8b0fdc80-a2cd-11eb-84b2-e670ea75c468.png)

There is not much performance gain when keeping the preload but there is definitely an issue when the preload is there, removing it