### PR TITLE
Display snack on url

### DIFF
--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -61,5 +61,13 @@
   },
   "date_time": {
     "now": "now"
+  },
+  "snacks": {
+    "emailConfirmed": {
+      "title": "Your email has been confirmed"
+    },
+    "emailUnsibscribed": {
+      "title": "You've been removed from the email news subscription"
+    }
   }
 }

--- a/public/locales/en-US/common.json
+++ b/public/locales/en-US/common.json
@@ -66,8 +66,8 @@
     "emailConfirmed": {
       "title": "Your email has been confirmed"
     },
-    "emailUnsibscribed": {
-      "title": "You've been removed from the email news subscription"
+    "emailUnsubscribed": {
+      "title": "You've successfully unsubscribed from email notifications"
     }
   }
 }

--- a/src/components/Snacks/Snack.module.scss
+++ b/src/components/Snacks/Snack.module.scss
@@ -11,6 +11,7 @@
   display: flex;
   align-items: center;
   line-height: 1.4;
+  box-shadow: 0 0 10px 0 rgba(128, 128, 128, 0.15);
 
   &.error,
   &.success {
@@ -24,7 +25,6 @@
   }
   &.success {
     background: var(--success);
-    box-shadow: inset 0 0 0 1000px rgba(0, 0, 0, 0.1);
   }
 }
 

--- a/src/components/Snacks/SnackViewControl.tsx
+++ b/src/components/Snacks/SnackViewControl.tsx
@@ -3,6 +3,7 @@ import { useReduxState } from 'src/rdx/useReduxState';
 
 import { Snack } from './Snack';
 import styled from 'styled-components/macro';
+import { useDisplaySnackOnSearchParams } from './useDisplaySnackOnSearchParams';
 
 const Container = styled.div`
   display: block;
@@ -15,6 +16,8 @@ const Container = styled.div`
 export const SnackViewControl = () => {
   const snackData = useReduxState('snacks');
   const snacks = Object.values(snackData);
+
+  useDisplaySnackOnSearchParams();
 
   return snacks?.length ? (
     <Container>

--- a/src/components/Snacks/useDisplaySnackOnSearchParams.tsx
+++ b/src/components/Snacks/useDisplaySnackOnSearchParams.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useHistory, useLocation } from 'react-router';
+import qs from 'query-string';
+import { createSnack } from 'src/rdx/snacks/snack.utils';
+import { useDispatch } from 'react-redux';
+import { snackActions } from 'src/rdx/snacks/snack.actions';
+import { SnackVariant } from 'src/types/Snack.types';
+import { useTranslation } from 'react-i18next';
+
+// title: React.ReactNode;
+// variant?: 'success' | 'start' | 'error' | 'default';
+// id?: string | number;
+// icon?: React.ReactNode;
+// description?: React.ReactNode;
+// /**
+//  * milliseconds
+//  */
+// autoHide?: number;
+// url?: string;
+
+export const getSnackBodyByKey = (
+  key: 'emailConfirmed' | 'emailUnsubscribed'
+) => {
+  switch (key) {
+    case 'emailConfirmed':
+      return createSnack({
+        title: 'snacks.emailConfirm.title',
+        id: key,
+      });
+    case 'emailUnsubscribed':
+      return createSnack({
+        title: 'snacks.emailUnsubscribed.title',
+        id: key,
+      });
+    default:
+      return null;
+  }
+};
+
+/**
+ * ?snack=[key&snackAutoHide=[time in ms]&snackVariant=['success' | 'start' | 'error' | 'default']
+ */
+export const useDisplaySnackOnSearchParams = () => {
+  const { search } = useLocation();
+  const { replace } = useHistory();
+  const d = useDispatch();
+  const { t } = useTranslation('common');
+
+  React.useEffect(() => {
+    const params = qs.parse(search);
+    const { snack, snackAutoHide, snackVariant, ...rest } = params;
+
+    const snacksToDisplay = typeof snack === 'string' ? [snack] : snack;
+
+    // default autoHide is 5s
+    const autoHide = Number(snackAutoHide) || 5000;
+
+    // default variant is success (green)
+    const variant: SnackVariant =
+      typeof snackVariant === 'string'
+        ? (snackVariant as SnackVariant)
+        : 'success';
+
+    if (snacksToDisplay) {
+      const snacksToPush = snacksToDisplay.map((key) => {
+        const title = t(`snacks.${key}.title`);
+        const description = t(`snacks.${key}.description`);
+        const snack = createSnack({
+          title,
+          ...(description !== `snacks.${key}.description`
+            ? { description }
+            : {}),
+          id: key,
+          autoHide,
+          variant,
+        });
+
+        return snack;
+      });
+
+      snacksToPush.forEach((snack) => d(snackActions.create(snack)));
+    }
+
+    /**
+     * remove snack info from the URL
+     */
+    // replace({
+    //   search: qs.stringify(rest),
+    // });
+  }, [search, d, replace, t]);
+
+  return null;
+};

--- a/src/components/Snacks/useDisplaySnackOnSearchParams.tsx
+++ b/src/components/Snacks/useDisplaySnackOnSearchParams.tsx
@@ -84,9 +84,9 @@ export const useDisplaySnackOnSearchParams = () => {
     /**
      * remove snack info from the URL
      */
-    // replace({
-    //   search: qs.stringify(rest),
-    // });
+    replace({
+      search: qs.stringify(rest),
+    });
   }, [search, d, replace, t]);
 
   return null;

--- a/src/types/Snack.types.ts
+++ b/src/types/Snack.types.ts
@@ -1,11 +1,11 @@
 import React from 'react';
-
+export type SnackVariant = 'success' | 'start' | 'error' | 'default';
 export type SnackOptions = {
   id: string | number;
   icon?: React.ReactNode;
   title: React.ReactNode;
   description?: React.ReactNode;
-  variant: 'success' | 'start' | 'error' | 'default';
+  variant: SnackVariant;
   /**
    * milliseconds
    */
@@ -17,7 +17,7 @@ export type SnackOptions = {
 
 export type SnackOptionsInput = {
   title: React.ReactNode;
-  variant?: 'success' | 'start' | 'error' | 'default';
+  variant?: SnackVariant;
   id?: string | number;
   icon?: React.ReactNode;
   description?: React.ReactNode;


### PR DESCRIPTION
?snack=[key]&snackAutoHide=[time in ms]&snackVariant=['success' | 'start' | 'error' | 'default']
key is stored in translation file

e.g. "emailConfirmed"

in common.json

```
  "snacks": {
    "emailConfirmed": {
      "title": "Your email has been confirmed"
    },
    "emailUnsibscribed": {
      "title": "You've been removed from the email news subscription"
    }
  }
```

with optional "description" property