### PR TITLE
Estimate rewards based on the average effective hashrate 

### DIFF
--- a/src/pages/MinerDashboard/Header/Stats.tsx
+++ b/src/pages/MinerDashboard/Header/Stats.tsx
@@ -147,6 +147,7 @@ export const HeaderStats: React.FC<{
 }> = () => {
   const minerHeaderStatsState = useReduxState('minerHeaderStats');
   const minerDetailsState = useReduxState('minerDetails');
+  const minerStatsState = useReduxState('minerStats');
   const data = minerHeaderStatsState.data;
   const activeTicker = useActiveCoinTicker();
   const activeCoin = useActiveCoin();
@@ -176,17 +177,11 @@ export const HeaderStats: React.FC<{
   const estimatedDailyEarnings = React.useMemo(() => {
     return poolStatsState.data?.averageHashrate &&
       dailyRewardPerGhState.data &&
-      minerHeaderStatsState.data?.roundShare
-      ? (poolStatsState.data?.averageHashrate *
-          dailyRewardPerGhState.data *
-          minerHeaderStatsState.data?.roundShare) /
-          1000000000
+      minerStatsState.data?.averageEffectiveHashrate
+      ? dailyRewardPerGhState.data *
+          (minerStatsState.data?.averageEffectiveHashrate / 1000000000)
       : 0;
-  }, [
-    poolStatsState.data,
-    dailyRewardPerGhState.data,
-    minerHeaderStatsState.data,
-  ]);
+  }, [poolStatsState.data, dailyRewardPerGhState.data, minerStatsState.data]);
 
   const estimated = React.useMemo(() => {
     return {

--- a/src/pages/MinerDashboard/Rewards/MinerRewardStats.section.tsx
+++ b/src/pages/MinerDashboard/Rewards/MinerRewardStats.section.tsx
@@ -46,8 +46,7 @@ const getIndexInterval = (index: number) => {
 export const MinerRewardStatsSection: React.FC<{
   rewards: ApiMinerReward[];
   counterPrice: number;
-  averagePoolHashrate?: number | null;
-}> = ({ rewards, counterPrice = 0, averagePoolHashrate }) => {
+}> = ({ rewards, counterPrice = 0 }) => {
   const dailyRewardPerGhState = useAsyncState('dailyRewGh', 0);
   const coinTicker = useActiveCoinTicker();
   const counterTicker = useCounterTicker();
@@ -56,7 +55,7 @@ export const MinerRewardStatsSection: React.FC<{
   const { t } = useTranslation('dashboard');
   const currencyFormatter = useLocalizedCurrencyFormatter();
 
-  const headerStatsState = useReduxState('minerHeaderStats');
+  const minerStatsState = useReduxState('minerStats');
 
   React.useEffect(() => {
     dailyRewardPerGhState.start(
@@ -106,13 +105,10 @@ export const MinerRewardStatsSection: React.FC<{
 
   const futureData = React.useMemo(() => {
     const daily =
-      averagePoolHashrate &&
       dailyRewardPerGhState.data &&
-      headerStatsState.data?.roundShare
-        ? (averagePoolHashrate *
-            dailyRewardPerGhState.data *
-            headerStatsState.data?.roundShare) /
-          1000000000
+      minerStatsState.data?.averageEffectiveHashrate
+        ? (minerStatsState.data?.averageEffectiveHashrate / 1000000000) *
+          dailyRewardPerGhState.data
         : 0;
 
     return [1, 7, 30.5].map((item) => ({
@@ -126,10 +122,9 @@ export const MinerRewardStatsSection: React.FC<{
         : '-',
     }));
   }, [
-    averagePoolHashrate,
     dailyRewardPerGhState.data,
     activeCoin,
-    headerStatsState.data?.roundShare,
+    minerStatsState.data?.averageEffectiveHashrate,
     counterPrice,
     activeCoinFormatter,
     currencyFormatter,

--- a/src/pages/MinerDashboard/Rewards/MinerRewards.page.tsx
+++ b/src/pages/MinerDashboard/Rewards/MinerRewards.page.tsx
@@ -55,7 +55,6 @@ export const MinerRewardsPage = () => {
       <MinerRewardStatsSection
         counterPrice={minerRewardsState.data?.price || 0}
         rewards={minerRewardsState.data?.data || []}
-        averagePoolHashrate={poolStatsState.data?.averageHashrate}
       />
       <MinerPplnsStats
         averagePoolHashrate={poolStatsState.data?.averageHashrate}


### PR DESCRIPTION
Previously the rewards estimation was using round share and average pool hashrate (3 hours). Because of a huge duration difference between the average pool hashrate and the share log (3 hours and 10 minutes), income estimations were incorrect when the hashrate doubled with a lot of hashrate is rented.