### PR TITLE
Fix website crashes on older iOS versions

### DIFF
--- a/src/utils/si.utils.ts
+++ b/src/utils/si.utils.ts
@@ -28,7 +28,7 @@ export const useLocalizedCurrencyFormatter = (currency?: string) => {
     style: 'currency',
     currency: currency || counterTicker,
     maximumFractionDigits: 2,
-    currencyDisplay: 'narrowSymbol',
+    currencyDisplay: 'symbol',
   });
 };
 


### PR DESCRIPTION
Fixes #224.

The crashes are caused because of the missing implementation of `narrowSymbol` in `currencyFormatter` under older versions of iOS (14.4 and lower). This PR replaces `narrowSymbol` with just `symbol`.