### PR TITLE
Bugfix/issue 335

### DIFF
--- a/src/pages/MinerDashboard/Header/Stats.tsx
+++ b/src/pages/MinerDashboard/Header/Stats.tsx
@@ -2,17 +2,11 @@ import React, { useState } from 'react';
 
 import { ApiPoolCoin } from 'src/types/PoolCoin.types';
 import { useReduxState } from 'src/rdx/useReduxState';
-import {
-  useActiveCoin,
-  useActiveCoinTicker,
-} from 'src/rdx/localSettings/localSettings.hooks';
+import { useActiveCoin } from 'src/rdx/localSettings/localSettings.hooks';
 import styled from 'styled-components/macro';
 import { Card, CardGrid, CardTitle } from 'src/components/layout/Card';
 import { useLocalizedActiveCoinValueFormatter } from 'src/hooks/useDisplayReward';
 import { StatItem } from 'src/components/StatItem';
-import { useDailyRewardPerGhState } from 'src/hooks/useDailyRewardPerGhState';
-import { poolStatsGet } from 'src/rdx/poolStats/poolStats.actions';
-import { useDispatch } from 'react-redux';
 import { useLocalStorageState } from 'src/hooks/useLocalStorageState';
 import { FaCalendar, FaCalendarDay, FaCalendarWeek } from 'react-icons/fa';
 import { Tooltip, TooltipContent } from 'src/components/Tooltip';
@@ -148,14 +142,13 @@ export const HeaderStats: React.FC<{
   const minerHeaderStatsState = useReduxState('minerHeaderStats');
   const minerDetailsState = useReduxState('minerDetails');
   const minerStatsState = useReduxState('minerStats');
-  const data = minerHeaderStatsState.data;
-  const activeTicker = useActiveCoinTicker();
-  const activeCoin = useActiveCoin();
-  const settings = minerDetailsState.data;
-  const d = useDispatch();
   const poolStatsState = useReduxState('poolStats');
-  const activeCoinFormatter = useLocalizedActiveCoinValueFormatter();
+  const activeCoin = useActiveCoin();
+  const data = minerHeaderStatsState.data;
+  const settings = minerDetailsState.data;
+
   const { t } = useTranslation('dashboard');
+  const activeCoinFormatter = useLocalizedActiveCoinValueFormatter();
   const currencyFormatter = useLocalizedCurrencyFormatter();
 
   const [
@@ -163,25 +156,20 @@ export const HeaderStats: React.FC<{
     setEstimateInterval,
   ] = useLocalStorageState<EstimateInterval>('estimateInterval', 1);
 
-  React.useEffect(() => {
-    d(poolStatsGet(activeTicker));
-  }, [activeTicker, d]);
-
   const balance = activeCoinFormatter(data?.balance, {
     maximumFractionDigits: 6,
   });
-  const tickerBalance = currencyFormatter(data?.balanceCountervalue || 0);
 
-  const dailyRewardPerGhState = useDailyRewardPerGhState();
+  const tickerBalance = currencyFormatter(data?.balanceCountervalue || 0);
 
   const estimatedDailyEarnings = React.useMemo(() => {
     return poolStatsState.data?.averageHashrate &&
-      dailyRewardPerGhState.data &&
+      minerHeaderStatsState.data?.dailyRewardsPerGh &&
       minerStatsState.data?.averageEffectiveHashrate
-      ? dailyRewardPerGhState.data *
+      ? minerHeaderStatsState.data?.dailyRewardsPerGh *
           (minerStatsState.data?.averageEffectiveHashrate / 1000000000)
       : 0;
-  }, [poolStatsState.data, dailyRewardPerGhState.data, minerStatsState.data]);
+  }, [poolStatsState.data, minerHeaderStatsState.data, minerStatsState.data]);
 
   const estimated = React.useMemo(() => {
     return {

--- a/src/pages/MinerDashboard/MinerDashboard.page.tsx
+++ b/src/pages/MinerDashboard/MinerDashboard.page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+
 import {
   Route,
   RouteComponentProps,
@@ -9,14 +9,22 @@ import {
 } from 'react-router';
 import { Content } from 'src/components/layout/Content';
 import { Page, PageLoading } from 'src/components/layout/Page';
-import {
-  useActiveCoin,
-  useCounterTicker,
-} from 'src/rdx/localSettings/localSettings.hooks';
+
+import { useDispatch } from 'react-redux';
+import { useReduxState } from 'src/rdx/useReduxState';
+import { minerRewardsGet } from 'src/rdx/minerRewards/minerRewards.actions';
 import { minerDetailsGet } from 'src/rdx/minerDetails/minerDetails.actions';
 import { minerHeaderStatsGet } from 'src/rdx/minerHeaderStats/minerHeaderStats.actions';
 import { minerStatsGet } from 'src/rdx/minerStats/minerStats.actions';
 import { minerStatsChartGet } from 'src/rdx/minerStatsChart/minerStatsCharts.actions';
+import { minerWorkersGet } from 'src/rdx/minerWorkers/minerWorkers.actions';
+import { localSettingsSet } from 'src/rdx/localSettings/localSettings.actions';
+import { poolStatsGet } from 'src/rdx/poolStats/poolStats.actions';
+import {
+  useActiveCoin,
+  useCounterTicker,
+} from 'src/rdx/localSettings/localSettings.hooks';
+
 import { AccountHeader } from './Header/AccountHeader';
 import { HeaderGreetings } from './Header/Greetings';
 import { HeaderStats } from './Header/Stats';
@@ -30,8 +38,7 @@ import { MinerPaymentsPage } from './Payments/MinerPayments.page';
 import { Helmet } from 'react-helmet-async';
 import { MinerBlocksPage } from './Blocks/MinerBlocks.page';
 import { MinerRewardsPage } from './Rewards/MinerRewards.page';
-import { localSettingsSet } from 'src/rdx/localSettings/localSettings.actions';
-import { useReduxState } from 'src/rdx/useReduxState';
+
 import { useActiveSearchParamWorker } from 'src/hooks/useActiveQueryWorker';
 import { useAsyncState } from 'src/hooks/useAsyncState';
 import { fetchApi } from 'src/utils/fetchApi';
@@ -103,7 +110,7 @@ export const MinerDashboardPageContent: React.FC<
       d(minerHeaderStatsGet(coinTicker, address, counterTicker)),
       d(minerDetailsGet(coinTicker, address)),
     ]);
-  }, [coinTicker, address, d, counterTicker]);
+  }, [coinTicker, address, counterTicker]);
 
   const loadMinerStats = React.useCallback(() => {
     return d(
@@ -113,7 +120,7 @@ export const MinerDashboardPageContent: React.FC<
         typeof worker === 'string' ? worker : undefined
       )
     );
-  }, [coinTicker, address, d, worker]);
+  }, [coinTicker, address, worker]);
 
   const loadMinerChartStats = React.useCallback(() => {
     return d(
@@ -123,7 +130,7 @@ export const MinerDashboardPageContent: React.FC<
         typeof worker === 'string' ? worker : undefined
       )
     );
-  }, [coinTicker, address, d, worker]);
+  }, [coinTicker, address, worker]);
 
   const loadAll = React.useCallback(() => {
     return Promise.all([loadMinerStats(), loadHeader(), loadMinerChartStats()]);
@@ -135,22 +142,16 @@ export const MinerDashboardPageContent: React.FC<
       poolCoins.data &&
       poolCoins.data.coins.find((item) => item.ticker === coinTicker)
     ) {
+      console.log('useEffect with coin ' + coinTicker);
       d(localSettingsSet({ coin: coinTicker }));
+      d(poolStatsGet(coinTicker));
+      loadHeader();
+      loadMinerStats();
+      loadMinerChartStats();
+      d(minerWorkersGet(coinTicker, address));
+      d(minerRewardsGet(coinTicker, address, counterTicker));
     }
-  }, [coinTicker, d, poolCoins.data]);
-
-  React.useEffect(() => {
-    loadHeader();
-    // eslint-disable-next-line
-  }, [loadHeader]);
-
-  React.useEffect(() => {
-    loadMinerStats();
-  }, [loadMinerStats]);
-
-  React.useEffect(() => {
-    loadMinerChartStats();
-  }, [loadMinerChartStats]);
+  }, [coinTicker, poolCoins.data]);
 
   return (
     <>
@@ -172,6 +173,7 @@ export const MinerDashboardPageContent: React.FC<
             />
             <Spacer />
             <MinerDetails coin={activeCoin} />
+            {activeCoin?.name}
             <HeaderStats coin={activeCoin} />
           </Content>
           <TabLinkContainer>
@@ -267,6 +269,7 @@ export const MinerDashboardPage: React.FC<
             message: 'Address not found',
           });
         }
+        localSettingsSet({ coin: res });
         return res;
       })
     );

--- a/src/pages/MinerDashboard/MinerDashboard.page.tsx
+++ b/src/pages/MinerDashboard/MinerDashboard.page.tsx
@@ -110,6 +110,7 @@ export const MinerDashboardPageContent: React.FC<
       d(minerHeaderStatsGet(coinTicker, address, counterTicker)),
       d(minerDetailsGet(coinTicker, address)),
     ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, address, counterTicker]);
 
   const loadMinerStats = React.useCallback(() => {
@@ -120,6 +121,7 @@ export const MinerDashboardPageContent: React.FC<
         typeof worker === 'string' ? worker : undefined
       )
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, address, worker]);
 
   const loadMinerChartStats = React.useCallback(() => {
@@ -130,6 +132,7 @@ export const MinerDashboardPageContent: React.FC<
         typeof worker === 'string' ? worker : undefined
       )
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, address, worker]);
 
   const loadAll = React.useCallback(() => {
@@ -151,6 +154,7 @@ export const MinerDashboardPageContent: React.FC<
       d(minerWorkersGet(coinTicker, address));
       d(minerRewardsGet(coinTicker, address, counterTicker));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, poolCoins.data]);
 
   return (

--- a/src/pages/MinerDashboard/MinerDashboard.page.tsx
+++ b/src/pages/MinerDashboard/MinerDashboard.page.tsx
@@ -173,7 +173,6 @@ export const MinerDashboardPageContent: React.FC<
             />
             <Spacer />
             <MinerDetails coin={activeCoin} />
-            {activeCoin?.name}
             <HeaderStats coin={activeCoin} />
           </Content>
           <TabLinkContainer>

--- a/src/pages/MinerDashboard/MinerDashboard.page.tsx
+++ b/src/pages/MinerDashboard/MinerDashboard.page.tsx
@@ -145,7 +145,6 @@ export const MinerDashboardPageContent: React.FC<
       poolCoins.data &&
       poolCoins.data.coins.find((item) => item.ticker === coinTicker)
     ) {
-      console.log('useEffect with coin ' + coinTicker);
       d(localSettingsSet({ coin: coinTicker }));
       d(poolStatsGet(coinTicker));
       loadHeader();

--- a/src/pages/MinerDashboard/Rewards/MinerRewards.page.tsx
+++ b/src/pages/MinerDashboard/Rewards/MinerRewards.page.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useRouteMatch } from 'react-router';
-import { useAsyncState } from 'src/hooks/useAsyncState';
-import {
-  useActiveCoinTicker,
-  useCounterTicker,
-} from 'src/rdx/localSettings/localSettings.hooks';
 import { useReduxState } from 'src/rdx/useReduxState';
-import { ApiMinerReward } from 'src/types/Miner.types';
-import { fetchApi } from 'src/utils/fetchApi';
 import { MinerPplnsStats } from './MinerPplnsStats.section';
 import { MinerRewardStatsSection } from './MinerRewardStats.section';
 import { MinerRewardsBlocksSection } from './MinerReportBlocks.section';
@@ -20,26 +13,7 @@ export const MinerRewardsPage = () => {
   } = useRouteMatch<{ address: string }>();
 
   const poolStatsState = useReduxState('poolStats');
-
-  const minerRewardsState = useAsyncState<{
-    price: number;
-    data: ApiMinerReward[];
-  }>('minerRewards', { price: 0, data: [] });
-  const coinTicker = useActiveCoinTicker();
-  const counterTicker = useCounterTicker();
-
-  React.useEffect(() => {
-    minerRewardsState.start(
-      fetchApi('/miner/rewards', {
-        query: {
-          address,
-          coin: coinTicker,
-          countervalue: counterTicker,
-        },
-      })
-    );
-    // eslint-disable-next-line
-  }, [address, coinTicker, counterTicker]);
+  const minerRewardsState = useReduxState('minerRewards');
 
   return (
     <>

--- a/src/pages/MinerDashboard/Stats/Workers.section.tsx
+++ b/src/pages/MinerDashboard/Stats/Workers.section.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import DynamicList, {
   DynamicListColumn,
 } from 'src/components/layout/List/List';
 import { Mono, Ws } from 'src/components/Typo/Typo';
-import {
-  useActiveCoin,
-  useActiveCoinTicker,
-} from 'src/rdx/localSettings/localSettings.hooks';
+import { useActiveCoin } from 'src/rdx/localSettings/localSettings.hooks';
 import { useReduxState } from 'src/rdx/useReduxState';
 import { ApiMinerWorker } from 'src/types/Miner.types';
 import { useLocalizedDateFormatter } from 'src/utils/date.utils';

--- a/src/pages/MinerDashboard/Stats/Workers.section.tsx
+++ b/src/pages/MinerDashboard/Stats/Workers.section.tsx
@@ -8,7 +8,6 @@ import {
   useActiveCoin,
   useActiveCoinTicker,
 } from 'src/rdx/localSettings/localSettings.hooks';
-import { minerWorkersGet } from 'src/rdx/minerWorkers/minerWorkers.actions';
 import { useReduxState } from 'src/rdx/useReduxState';
 import { ApiMinerWorker } from 'src/types/Miner.types';
 import { useLocalizedDateFormatter } from 'src/utils/date.utils';
@@ -409,15 +408,9 @@ const MinerWorkersTable: React.FC<{
 export const MinerWorkers: React.FC<{
   address: string;
 }> = ({ address }) => {
-  const d = useDispatch();
-  const coinTicker = useActiveCoinTicker();
   const { t } = useTranslation('dashboard');
 
   const minerWorkersState = useReduxState('minerWorkers');
-
-  React.useEffect(() => {
-    d(minerWorkersGet(coinTicker, address));
-  }, [coinTicker, address, d]);
 
   const dataWithTotalShare = React.useMemo(() => {
     return (minerWorkersState.data || []).map((item) => ({

--- a/src/rdx/minerHeaderStats/minerHeaderStats.actions.ts
+++ b/src/rdx/minerHeaderStats/minerHeaderStats.actions.ts
@@ -23,6 +23,7 @@ export const minerHeaderStatsGet = (
       ),
       fetchApi<number>('/miner/roundShare', { query }),
       fetchApi<number>('/pool/averageBlockReward', { query }),
+      fetchApi<number>('/pool/dailyRewardPerGigahashSec', { query: { coin } }),
     ]).then((res) => {
       return {
         ...res[0],
@@ -30,6 +31,7 @@ export const minerHeaderStatsGet = (
         countervaluePrice: res[1].price,
         roundShare: res[2],
         averageBlockShare: res[3],
+        dailyRewardsPerGh: res[4],
       };
     }),
   };

--- a/src/rdx/minerRewards/minerRewards.actions.ts
+++ b/src/rdx/minerRewards/minerRewards.actions.ts
@@ -1,0 +1,15 @@
+import { ApiMinerReward } from 'src/types/Miner.types';
+import { fetchApi } from 'src/utils/fetchApi';
+
+export const minerRewardsGet = (
+  coin: string,
+  address: string,
+  countervalue: string
+) => {
+  return {
+    type: '@minerRewards/GET',
+    payload: fetchApi('/miner/rewards', {
+      query: { coin, address, countervalue },
+    }),
+  };
+};

--- a/src/rdx/minerRewards/minerRewards.actions.ts
+++ b/src/rdx/minerRewards/minerRewards.actions.ts
@@ -1,4 +1,3 @@
-import { ApiMinerReward } from 'src/types/Miner.types';
 import { fetchApi } from 'src/utils/fetchApi';
 
 export const minerRewardsGet = (

--- a/src/rdx/minerRewards/minerRewards.reducer.ts
+++ b/src/rdx/minerRewards/minerRewards.reducer.ts
@@ -1,0 +1,16 @@
+import {
+  createGetReducer,
+  composeReducers,
+  defaultReducerState,
+  DefaultState,
+} from 'src/rdx/@utils';
+import { ApiMinerRewards } from 'src/types/Miner.types';
+
+export const defaultState = defaultReducerState as DefaultState<ApiMinerRewards>;
+const getReducer = createGetReducer<ApiMinerRewards>(defaultState, {
+  flushOnStart: true,
+});
+export const reducer = composeReducers(
+  '@minerRewards',
+  defaultState
+)(getReducer);

--- a/src/rdx/rootReducer.ts
+++ b/src/rdx/rootReducer.ts
@@ -8,6 +8,7 @@ import * as minerHeaderStats from 'src/rdx/minerHeaderStats/minerHeaderStats.red
 import * as minerDetails from 'src/rdx/minerDetails/minerDetails.reducer';
 import * as minerStats from 'src/rdx/minerStats/minerStats.reducer';
 import * as minerWorkers from 'src/rdx/minerWorkers/minerWorkers.reducer';
+import * as minerRewards from 'src/rdx/minerRewards/minerRewards.reducer';
 import * as minerPayments from 'src/rdx/minerPayments/minerPayments.reducer';
 import * as snacks from 'src/rdx/snacks/snacks.reducer';
 import * as poolStats from 'src/rdx/poolStats/poolStats.reducer';
@@ -26,6 +27,7 @@ export const defaultReduxState = {
   minerDetails: minerDetails.defaultState,
   minerStats: minerStats.defaultState,
   minerWorkers: minerWorkers.defaultState,
+  minerRewards: minerRewards.defaultState,
   minerPayments: minerPayments.defaultState,
   snacks: snacks.defaultState,
   poolStats: poolStats.defaultState,
@@ -44,6 +46,7 @@ const combinedReducer = combineReducers({
   minerDetails: minerDetails.reducer,
   minerStats: minerStats.reducer,
   minerWorkers: minerWorkers.reducer,
+  minerRewards: minerRewards.reducer,
   minerPayments: minerPayments.reducer,
   snacks: snacks.reducer,
   poolStats: poolStats.reducer,

--- a/src/types/Miner.types.ts
+++ b/src/types/Miner.types.ts
@@ -17,6 +17,7 @@ export type ApiMinerHeaderStats = {
   balance: number;
   balanceCountervalue: number;
   countervaluePrice: number;
+  dailyRewardsPerGh: number;
   roundShare: number;
   workersOffline: number;
   workersOnline: number;
@@ -74,4 +75,9 @@ export type ApiMinerPayments = {
 export type ApiMinerReward = {
   timestamp: number;
   totalRewards: number;
+};
+
+export type ApiMinerRewards = {
+  price: number;
+  data: ApiMinerReward[];
 };


### PR DESCRIPTION
## Issue
Was able to test this some more and fix the underlying problem.
The issue would crop up when you loaded a dashboard for a new coin and the app would use the last coin you were using thats stored in local storage.

This then would fire API calls with the incorrect coin attached, for example this is how our XCH api calls looked:
`https://api.flexpool.io/v2/miner/shareLog?address=xch1t7whgxezk3phddvwlc8ztp89qxsqvns6yvshvuve240l20ejvc9qtcy85k&coin=eth`

You can see the incorrect ETH coin param at the end.

## Solution
The fix came down to when and how we store/retrieve the users current coin in localStorage.

I reorganized some api calls that were firing off inside components before our app was ready and unified them in redux store so that they all fire off and store data in the correct order.

This fix also addresses the rewards tab not showing properly when the wrong estimated daily earnings issue is happening.