### PR TITLE
:bug: Add loading animation when switching coin

### DIFF
--- a/pages/blocks.tsx
+++ b/pages/blocks.tsx
@@ -86,7 +86,9 @@ function BlocksPage() {
             }
             title={<>{t('average_luck')}&nbsp;</>}
             value={
-              statsState.data && <Luck value={statsState.data.averageLuck} />
+              statsState.isLoading || !statsState.data ? undefined : (
+                <Luck value={statsState.data.averageLuck} />
+              )
             }
           />
           <StatBox
@@ -97,7 +99,9 @@ function BlocksPage() {
             }
             title={t('current_luck')}
             value={
-              statsState.data && <Luck value={statsState.data.currentLuck} />
+              statsState.isLoading || !statsState.data ? undefined : (
+                <Luck value={statsState.data.currentLuck} />
+              )
             }
           />
           <StatBox
@@ -107,17 +111,18 @@ function BlocksPage() {
                 : t('network_hashrate')
             }
             value={
-              statsState.data &&
-              `${siFormatter(
-                statsState.data.networkHashrate *
-                  Number(activeCoin?.difficultyFactor),
-                {
-                  unit:
-                    activeCoin?.hashrateUnit === 'H'
-                      ? 'H/s'
-                      : activeCoin?.hashrateUnit,
-                }
-              )}`
+              statsState.isLoading || !statsState.data
+                ? undefined
+                : `${siFormatter(
+                    statsState.data.networkHashrate *
+                      Number(activeCoin?.difficultyFactor),
+                    {
+                      unit:
+                        activeCoin?.hashrateUnit === 'H'
+                          ? 'H/s'
+                          : activeCoin?.hashrateUnit,
+                    }
+                  )}`
             }
           />
           <StatBox
@@ -132,13 +137,14 @@ function BlocksPage() {
             }
             title={t('network_difficulty')}
             value={
-              statsState.data &&
-              `${siFormatter(statsState.data.networkDifficulty, {
-                unit:
-                  String(activeCoin?.ticker) === 'xch'
-                    ? 'PT'
-                    : activeCoin?.hashrateUnit.split('/')[0],
-              })}`
+              statsState.isLoading || !statsState.data
+                ? undefined
+                : `${siFormatter(statsState.data.networkDifficulty, {
+                    unit:
+                      String(activeCoin?.ticker) === 'xch'
+                        ? 'PT'
+                        : activeCoin?.hashrateUnit.split('/')[0],
+                  })}`
             }
           />
         </StatBoxContainer>


### PR DESCRIPTION
This PR aims to fix #382 

![Kapture 2021-08-22 at 23 27 32](https://user-images.githubusercontent.com/5182324/130360925-4d39504d-2d7e-4a53-8d6f-2ad9ed328dff.gif)

A skeleton animation is provided when switching coin. I believe this is acceptable because the content is dynamically fetched and we would need a loader for better UX.
