### PR TITLE
Avoid re render of table row on hover

### DIFF
--- a/src/components/layout/List/List.tsx
+++ b/src/components/layout/List/List.tsx
@@ -141,7 +141,9 @@ export const DynamicList = <D extends {}, CP extends {}>(
     renderRowTooltipContent,
   } = props;
 
-  const [lastMouseOver, setLastMouseOver] = React.useState<number | null>();
+  const [lastMouseOver, setLastMouseOver] = React.useState<{
+    hoverIndex: number | null;
+  }>({ hoverIndex: null });
 
   const headEl = React.useMemo(() => {
     return (
@@ -197,7 +199,10 @@ export const DynamicList = <D extends {}, CP extends {}>(
               ))}
             </tbody>
           )) || (
-            <tbody>
+            <tbody
+              onMouseEnter={() => setLastMouseOver({ hoverIndex: null })}
+              onMouseLeave={() => setLastMouseOver({ ...lastMouseOver })}
+            >
               {columns &&
                 data &&
                 data.length > 0 &&
@@ -209,8 +214,10 @@ export const DynamicList = <D extends {}, CP extends {}>(
                       onRowClickAllowed={onRowClickAllowed as any}
                       index={index}
                       key={(item as any).name || index}
-                      isHighlighted={index === lastMouseOver}
-                      handleActiveHover={setLastMouseOver}
+                      isHighlighted={index === lastMouseOver.hoverIndex}
+                      handleActiveHover={(rowIndex) => {
+                        lastMouseOver.hoverIndex = rowIndex;
+                      }}
                       columns={columns as any}
                       config={config}
                       renderRowTooltipContent={renderRowTooltipContent as any}

--- a/src/components/layout/List/components.tsx
+++ b/src/components/layout/List/components.tsx
@@ -51,6 +51,7 @@ const Tr = styled.tr<{ clickable?: boolean }>`
       color: var(--primary);
       text-decoration: underline;
     }
+    background: rgba(128, 128, 128, 0.06);
   }
 
   ${(p) =>


### PR DESCRIPTION
The new method keeps the index of the row but it does not render, since hoverIndex is inside an object it will not trigger re-render until a new object is set.

onMouseEnter -> It will set the hoverIndex to null so the previous index won't show, and there won't be two active rows.

onMouseLeave -> It set hoverIndex and force to re-render, so when mouse hover is outside the table body it shows the row that last of hovered.

onhover in CSS will take care of when the mouse is on the table row.