### PR TITLE
Add ip caption on payout setting

### DIFF
--- a/public/locales/en-US/dashboard.json
+++ b/public/locales/en-US/dashboard.json
@@ -3,6 +3,7 @@
     "cta": "Settings",
     "title": "Settings",
     "ip": "IP address for verification",
+    "ip_caption": "Usually the public IP address of your largest miner or farmer",
     "ip_hint": "Hint: You are visiting this webpage from",
     "ip_description": "If your worker is using proxy address, e.g. your worker is dual mining through a ZIL pool, please use the proxy address instead.",
     "high_fees_warning": "A payout limit under 0.05 ETH will result in high gas fees that will be deducted from your payment. Please set up a higher payout limit if possible.",

--- a/public/locales/en-US/dashboard.json
+++ b/public/locales/en-US/dashboard.json
@@ -3,7 +3,7 @@
     "cta": "Settings",
     "title": "Settings",
     "ip": "IP address for verification",
-    "ip_caption": "Usually the public IP address of your largest miner or farmer",
+    "ip_caption": "The IP required for verification is the one that has the highest number of shares submitted during the past 24 hours.",
     "ip_hint": "Hint: You are visiting this webpage from",
     "ip_description": "If your worker is using proxy address, e.g. your worker is dual mining through a ZIL pool, please use the proxy address instead.",
     "high_fees_warning": "A payout limit under 0.05 ETH will result in high gas fees that will be deducted from your payment. Please set up a higher payout limit if possible.",

--- a/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
+++ b/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
@@ -529,10 +529,11 @@ export const PayoutSettings: React.FC<{
                 <Spacer />
                 <TextField
                   name="ip"
-                  label={t('dashboard:settings.ip')}
+                  label={`${t('dashboard:settings.ip')}*`}
                   placeholder={minerSettings.data!.ipAddress}
                 />
                 <div>
+                  <p>*{t('dashboard:settings.ip_caption')} </p>
                   <p>
                     {t('dashboard:settings.ip_hint')}{' '}
                     <b>{minerSettings.data!.clientIPAddress}</b>.

--- a/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
+++ b/src/pages/MinerDashboard/Settings/PayoutSettings.tsx
@@ -533,7 +533,9 @@ export const PayoutSettings: React.FC<{
                   placeholder={minerSettings.data!.ipAddress}
                 />
                 <div>
-                  <p>*{t('dashboard:settings.ip_caption')} </p>
+                  <p>
+                    <i>*{t('dashboard:settings.ip_caption')}</i>
+                  </p>
                   <p>
                     {t('dashboard:settings.ip_hint')}{' '}
                     <b>{minerSettings.data!.clientIPAddress}</b>.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5182324/130807158-eb0b1aec-8601-4396-9e76-462bebc030b6.png)

Caption was a bit too long to display next to the title. So used asterisk and footnote. I think it's clear.