### PR TITLE
Fix incorrect dynamic route file name

### DIFF
--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -122,8 +122,8 @@ export const MinerDashboardPageContent: React.FC<{
 
   const loadHeader = React.useCallback(() => {
     return Promise.all([
-      d(minerHeaderStatsGet(coinTicker, address[0], counterTicker)),
-      d(minerDetailsGet(coinTicker, address[0])),
+      d(minerHeaderStatsGet(coinTicker, address, counterTicker)),
+      d(minerDetailsGet(coinTicker, address)),
     ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, address, counterTicker]);
@@ -132,7 +132,7 @@ export const MinerDashboardPageContent: React.FC<{
     return d(
       minerStatsGet(
         coinTicker,
-        address[0],
+        address,
         typeof worker === 'string' ? worker : undefined
       )
     );
@@ -143,7 +143,7 @@ export const MinerDashboardPageContent: React.FC<{
     return d(
       minerStatsChartGet(
         coinTicker,
-        address[0],
+        address,
         typeof worker === 'string' ? worker : undefined
       )
     );
@@ -166,7 +166,7 @@ export const MinerDashboardPageContent: React.FC<{
       loadMinerStats();
       loadMinerChartStats();
       d(minerWorkersGet(coinTicker, address));
-      d(minerRewardsGet(coinTicker, address[0], counterTicker));
+      d(minerRewardsGet(coinTicker, address, counterTicker));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [coinTicker, poolCoins?.data, worker, address]);
@@ -205,7 +205,7 @@ export const MinerDashboardPageContent: React.FC<{
             <HeaderGreetings onRefresh={loadAll} />
             <AccountHeader
               coin={activeCoin}
-              address={address[0]}
+              address={address}
               onRefresh={loadAll}
             />
             <Spacer />
@@ -236,25 +236,19 @@ export const MinerDashboardPageContent: React.FC<{
             <TabContent id="workertabs">
               <Content>
                 <TabPanel>
-                  <DynamicMinerStatsPage
-                    address={address[0]}
-                    coin={coinTicker}
-                  />
+                  <DynamicMinerStatsPage address={address} coin={coinTicker} />
                 </TabPanel>
                 <TabPanel>
                   <DynamicMinerPaymentsPage
-                    address={address[0]}
+                    address={address}
                     coin={coinTicker}
                   />
                 </TabPanel>
                 <TabPanel>
-                  <DynamicMinerRewardsPage address={address[0]} />
+                  <DynamicMinerRewardsPage address={address} />
                 </TabPanel>
                 <TabPanel>
-                  <DynamicMinerBlocksPage
-                    address={address[0]}
-                    coin={coinTicker}
-                  />
+                  <DynamicMinerBlocksPage address={address} coin={coinTicker} />
                 </TabPanel>
               </Content>
             </TabContent>

--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -172,7 +172,7 @@ export const MinerDashboardPageContent: React.FC<{
   }, [coinTicker, poolCoins?.data, worker, address]);
 
   useEffect(() => {
-    if (typeof window !== undefined) {
+    if (typeof window !== 'undefined') {
       if (window.location.hash) {
         loadSelectedTabFromHash(window.location.hash.replace(/#/g, ''));
       }


### PR DESCRIPTION
This PR fixes #425

The previous implementation used [...address] ([Catch all](https://nextjs.org/docs/routing/dynamic-routes#catch-all-routes)), which results in `query.address` to be an array. Because `address` is used as an effect dependency, this caused unwanted effect runs.

<img width="400px" src="https://user-images.githubusercontent.com/5182324/132988837-3f7d392b-941f-4543-ba7d-fb33a8e2af7b.png" />

