### PR TITLE
Improve miner dashboard user experience

### DIFF
--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -380,7 +380,7 @@ export const MinerDashboardPage: React.FC<{
 
   return (
     <>
-      {locateAddressState.data === null && (
+      {locateAddressState.error !== null && (
         <Content>
           <TopBannerContainer>
             <InfoBox variant="warning">

--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -42,9 +42,9 @@ import { InfoBox } from 'src/components/InfoBox';
 import styled from 'styled-components';
 import { FaChartBar, FaCube, FaWallet } from 'react-icons/fa';
 import { useActiveSearchParamWorker } from 'src/hooks/useActiveQueryWorker';
-import useLocateAddress from 'src/hooks/useLocateAddress';
 import { getChecksumByTicker } from '@/utils/validators/checksum';
 import Warning from '@/assets/warning-icon.svg';
+import { fetchApi } from 'src/utils/fetchApi';
 
 const TabContent = styled.div`
   box-shadow: inset -1px 18px 19px -13px var(--bg-secondary);
@@ -363,24 +363,14 @@ const DynamicMinerBlocksPage = dynamic<{
 export const MinerDashboardPage: React.FC<{
   address: string;
   coinTicker: string;
+  isLocated: boolean;
 }> = (props) => {
-  const { address, coinTicker } = props;
+  const { isLocated } = props;
   const { t } = useTranslation('dashboard');
-  const locateAddressState = useLocateAddress({ coinTicker, address });
-  /**
-   * Still loading
-   */
-  if (locateAddressState.isLoading) {
-    return (
-      <PageLoading>
-        <LoaderSpinner center />
-      </PageLoading>
-    );
-  }
 
   return (
     <>
-      {locateAddressState.error !== null && (
+      {!isLocated && (
         <Content>
           <TopBannerContainer>
             <InfoBox variant="warning">
@@ -403,6 +393,8 @@ export const MinerDashboardPage: React.FC<{
 export default MinerDashboardPage;
 
 export async function getServerSideProps({ query, locale }) {
+  const { coin, address } = query;
+
   const checkSum = getChecksumByTicker(query.coin)(query.address);
 
   if (checkSum === null) {
@@ -414,6 +406,10 @@ export async function getServerSideProps({ query, locale }) {
     };
   }
 
+  const res = await fetchApi<string | null>('/miner/locateAddress', {
+    query: { address },
+  });
+
   return {
     props: {
       ...(await serverSideTranslations(locale, [
@@ -422,8 +418,9 @@ export async function getServerSideProps({ query, locale }) {
         'blocks',
         'cookie-consent',
       ])),
-      coinTicker: query.coin,
-      address: query.address,
+      coinTicker: coin,
+      address,
+      isLocated: res !== null,
     },
   };
 }

--- a/src/pages/MinerDashboard/Header/AccountHeader.tsx
+++ b/src/pages/MinerDashboard/Header/AccountHeader.tsx
@@ -49,6 +49,13 @@ const Address = styled(LinkOut)`
   }
 `;
 
+const CoinIconSkeleton = styled.div`
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  background: var(--bg-secondary);
+`;
+
 const RefreshButton = styled(Button)`
   font-size: 1.5rem;
   margin-right: 10px;
@@ -65,8 +72,10 @@ export const AccountHeader: React.FC<{
   return (
     <Wrap paddingShort>
       <AddressContainer>
-        {coin && (
+        {coin ? (
           <Img src={getCoinIconUrl(coin.ticker)} alt={`${coin.name} logo`} />
+        ) : (
+          <CoinIconSkeleton />
         )}
         <Address href={getCoinLink('wallet', address, coin?.ticker)}>
           {addressText}

--- a/src/pages/MinerDashboard/Header/Greetings.tsx
+++ b/src/pages/MinerDashboard/Header/Greetings.tsx
@@ -213,12 +213,12 @@ export const HeaderGreetings: React.FC<{ onRefresh: () => void }> = ({
           {activeCoin?.ticker === 'xch'
             ? t(`header.greet_desc_farm`, {
                 count: workersOnline,
-                hashrate,
+                hashrate: hashrate || '',
                 coin: activeCoin?.name,
               })
             : t(`header.greet_desc`, {
                 count: workersOnline,
-                hashrate,
+                hashrate: hashrate || '',
                 coin: activeCoin?.name,
               })}
         </span>


### PR DESCRIPTION
#### This PR 
1. Fixes a warning banner glitch
2. Add performance improvement on initial load

#### The glitch: 
Before:
![Kapture 2021-09-28 at 19 42 10](https://user-images.githubusercontent.com/5182324/135108979-02a498a2-04eb-42f8-b288-6ad425d133a2.gif)

After:
![Kapture 2021-09-28 at 20 53 17](https://user-images.githubusercontent.com/5182324/135109002-e60842f6-fdda-4708-a75d-9b5cbe2aa8b5.gif)

#### Performance Improvements
After moving 'locate address' logic to server side, we see a great improvements on miner dashboard's initial load speed. This is especially significant for new miners whose dashboard is not ready.

