### PR TITLE
Redirect `/[coin]/[address]/stats` to `/[coin]/[address]`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,13 @@ module.exports = withPWA(
     pwa: {
       dest: 'public',
       sw: 'service-worker.js',
-      publicExcludes: ['!locales', '!unused-locales', '!og', '!illustrations', '!svg'],
+      publicExcludes: [
+        '!locales',
+        '!unused-locales',
+        '!og',
+        '!illustrations',
+        '!svg',
+      ],
     },
     pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
     webpack: (config) => {
@@ -50,6 +56,12 @@ module.exports = withPWA(
         {
           source: '/get-started/xch',
           destination: '/get-started',
+          permanent: true,
+        },
+        // Some users use legacy URL: /miner/eth/0x8df8u../stats
+        {
+          source: '/miner/:coin/:address/:tab',
+          destination: '/miner/:coin/:address',
           permanent: true,
         },
         // Old Redirects from CRA app


### PR DESCRIPTION
Some users are using unsupported url such as `/[coin]/[address]/stats` or `/[coin]/[address]/payments`, which resulted in 404 page.

The correct url should be  `/[coin]/[address]#stats`

This PR resolves this issue by redirecting bad url to the correct one