### PR TITLE
Add more specific redirects for miner dashboard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -62,22 +62,22 @@ module.exports = withPWA(
         {
           source: '/miner/:coin/:address/stats',
           destination: '/miner/:coin/:address#stats',
-          permanent: true,
+          permanent: false,
         },
         {
           source: '/miner/:coin/:address/payments',
           destination: '/miner/:coin/:address#payments',
-          permanent: true,
+          permanent: false,
         },
         {
           source: '/miner/:coin/:address/rewards',
           destination: '/miner/:coin/:address#rewards',
-          permanent: true,
+          permanent: false,
         },
         {
           source: '/miner/:coin/:address/blocks',
           destination: '/miner/:coin/:address#blocks',
-          permanent: true,
+          permanent: false,
         },
         // Old Redirects from CRA app
         // {

--- a/next.config.js
+++ b/next.config.js
@@ -58,10 +58,25 @@ module.exports = withPWA(
           destination: '/get-started',
           permanent: true,
         },
-        // Some users use legacy URL: /miner/eth/0x8df8u../stats
+        // Redirect legacy URL, eg. /miner/eth/0x8df8u../stats
         {
-          source: '/miner/:coin/:address/:tab',
-          destination: '/miner/:coin/:address',
+          source: '/miner/:coin/:address/stats',
+          destination: '/miner/:coin/:address#stats',
+          permanent: true,
+        },
+        {
+          source: '/miner/:coin/:address/payments',
+          destination: '/miner/:coin/:address#payments',
+          permanent: true,
+        },
+        {
+          source: '/miner/:coin/:address/rewards',
+          destination: '/miner/:coin/:address#rewards',
+          permanent: true,
+        },
+        {
+          source: '/miner/:coin/:address/blocks',
+          destination: '/miner/:coin/:address#blocks',
           permanent: true,
         },
         // Old Redirects from CRA app


### PR DESCRIPTION
Remove the previous wild card redirect `/[coin]/[address]/[wildcard]`

Current redirect rule:
`/[coin]/[address]/stats` -> `/[coin]/[address]#stats`
`/[coin]/[address]/payments` -> `/[coin]/[address]#payments`
`/[coin]/[address]/rewards` -> `/[coin]/[address]#rewards`
`/[coin]/[address]/blocks` -> `/[coin]/[address]#blocks`

`/[coin]/[address]/foo` -> `/not-found`
`/[coin]/[address]/foo/bar` -> `/not-found`
