### PR TITLE
Hotfix page crash for miner's dashboard

### DIFF
--- a/src/pages/MinerDashboard/Payments/PaymentStats.section.tsx
+++ b/src/pages/MinerDashboard/Payments/PaymentStats.section.tsx
@@ -63,6 +63,15 @@ export const GeneralPaymentStatsSection: React.FC<{
     // eslint-disable-next-line
   }, [coin?.ticker, address, couterTicker]);
 
+  const averageCtaTooltip: string[] = React.useMemo(() => {
+    const tooltips = t('payments.transaction_fees.average_cta_tooltip', {
+      returnObjects: true,
+    });
+
+    if (typeof tooltips === 'string') return []; // return value of t() could be translation key when unmount
+    return tooltips;
+  }, [t]);
+
   const data = {
     ...asyncState.data,
     stats:
@@ -207,11 +216,7 @@ export const GeneralPaymentStatsSection: React.FC<{
                 icon={<span>{t('payments.transaction_fees.average_cta')}</span>}
               >
                 <TooltipContent>
-                  {(
-                    t('payments.transaction_fees.average_cta_tooltip', {
-                      returnObjects: true,
-                    }) as string[]
-                  ).map((item) => (
+                  {averageCtaTooltip.map((item) => (
                     <p key={item}>{item}</p>
                   ))}
                 </TooltipContent>


### PR DESCRIPTION
Fix #449 

This is caused by an unexpected behavior for the `t` function returned by `useTranslate`.
During unmount, the `t` function will return the translation key instead of the translated value. 

In this case, we are always expecting `string[]` instead of `string`.