### PR TITLE
Fix polygon address link

### DIFF
--- a/src/pages/MinerDashboard/Header/AccountHeader.tsx
+++ b/src/pages/MinerDashboard/Header/AccountHeader.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
+import styled, { keyframes } from 'styled-components';
 import NProgress from 'nprogress';
+import { BiRefresh, BiLoaderAlt } from 'react-icons/bi';
 import { CopyButton } from 'src/components/CopyButton';
 import { Img } from 'src/components/Img';
 import { Card } from 'src/components/layout/Card';
@@ -8,10 +10,9 @@ import { ApiPoolCoin } from 'src/types/PoolCoin.types';
 import { getCoinLink } from 'src/utils/coinLinks.utils';
 import { getCoinIconUrl } from 'src/utils/staticImage.utils';
 import { getChecksumByTicker } from 'src/utils/validators/checksum';
-import styled, { keyframes } from 'styled-components';
 import { MinerSettingsModal } from '../Settings/MinerSettings.modal';
 import { Button } from 'src/components/Button';
-import { BiRefresh, BiLoaderAlt } from 'react-icons/bi';
+import useMinerDetailsQuery from '@/hooks/api/useMinerDetailsQuery';
 
 const rotate = keyframes`
   from {
@@ -91,6 +92,15 @@ export const AccountHeader: React.FC<{
 }> = ({ coin, address, onRefresh }) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  const { data: minerDetails } = useMinerDetailsQuery({
+    coin: coin?.ticker,
+    address,
+  });
+
+  const coinName =
+    minerDetails &&
+    (minerDetails.network === 'mainnet' ? coin?.ticker : minerDetails.network);
+
   useEffect(() => {
     if (isRefreshing) {
       NProgress.start();
@@ -108,7 +118,7 @@ export const AccountHeader: React.FC<{
         ) : (
           <CoinIconSkeleton />
         )}
-        <Address href={getCoinLink('wallet', address, coin?.ticker)}>
+        <Address href={getCoinLink('wallet', address, coinName)}>
           {addressText}
         </Address>
         <CopyButton text={addressText || ''} />

--- a/src/utils/coinLinks.utils.ts
+++ b/src/utils/coinLinks.utils.ts
@@ -15,6 +15,7 @@ const transactionUrlMap = {
 
 const walletAddressUrlMap = {
   eth: 'https://etherscan.io/address/%v',
+  polygon: 'https://polygonscan.com/address/%v',
   xch: 'https://www.chiaexplorer.com/blockchain/address/%v',
 };
 


### PR DESCRIPTION
Fix #594 

![image](https://user-images.githubusercontent.com/5182324/151495988-3b36f190-18c1-4508-841a-bd699b40b43e.png)
This icon is left as it is since the user is technically still mining "Ethereum", so I don't think it makes sense to change this icon.

The user can see his/her network here:
![image](https://user-images.githubusercontent.com/5182324/151496104-cbb3d384-64a6-46dd-a310-0246f1108fc9.png)


