### PR TITLE
Improve payout chart UI

### DIFF
--- a/src/pages/MinerDashboard/Payments/Payments.chart.tsx
+++ b/src/pages/MinerDashboard/Payments/Payments.chart.tsx
@@ -62,14 +62,13 @@ const PaymentsChart: React.FC<{ address: string; coin?: ApiPoolCoin }> = ({
       };
 
       dateAxis.groupData = true;
-      dateAxis.groupCount = 100;
 
       dateAxis.groupIntervals.setAll([
         { timeUnit: 'minute', count: 1 },
         { timeUnit: 'day', count: 1 },
-        { timeUnit: 'week', count: 1 },
       ]);
 
+      dateAxis.dateFormats.setKey('minute', 'MMM dd HH:mm');
       dateAxis.dateFormats.setKey('hour', 'MMM dd HH:mm');
 
       dateAxis.adapter.add('getTooltipText', (text, target) => {

--- a/src/pages/MinerDashboard/Payments/Payments.chart.tsx
+++ b/src/pages/MinerDashboard/Payments/Payments.chart.tsx
@@ -57,13 +57,20 @@ const PaymentsChart: React.FC<{ address: string; coin?: ApiPoolCoin }> = ({
       dateAxis.renderer.grid.template.location = 0;
 
       dateAxis.baseInterval = {
-        timeUnit: 'hour',
+        timeUnit: 'minute',
         count: 1,
       };
 
       dateAxis.groupData = true;
+      dateAxis.groupCount = 100;
 
-      dateAxis.dateFormats.setKey('hour', ' MMM dd HH:mm');
+      dateAxis.groupIntervals.setAll([
+        { timeUnit: 'minute', count: 1 },
+        { timeUnit: 'day', count: 1 },
+        { timeUnit: 'week', count: 1 },
+      ]);
+
+      dateAxis.dateFormats.setKey('hour', 'MMM dd HH:mm');
 
       dateAxis.adapter.add('getTooltipText', (text, target) => {
         if (target.baseInterval.timeUnit === 'week') {

--- a/src/pages/MinerDashboard/Payments/Payments.chart.tsx
+++ b/src/pages/MinerDashboard/Payments/Payments.chart.tsx
@@ -32,6 +32,7 @@ const PaymentsChart: React.FC<{ address: string; coin?: ApiPoolCoin }> = ({
   address,
 }) => {
   const { t } = useTranslation('dashboard');
+  // FIXME: migrate to react query
   const asyncState = useAsyncState<
     {
       fee: number;
@@ -54,7 +55,34 @@ const PaymentsChart: React.FC<{ address: string; coin?: ApiPoolCoin }> = ({
       paymentsAxis.renderer.grid.template.disabled = true;
       let dateAxis = paymentsChart.xAxes.push(new DateAxis());
       dateAxis.renderer.grid.template.location = 0;
+
+      dateAxis.baseInterval = {
+        timeUnit: 'hour',
+        count: 1,
+      };
+
       dateAxis.groupData = true;
+
+      dateAxis.dateFormats.setKey('hour', ' MMM dd HH:mm');
+
+      dateAxis.adapter.add('getTooltipText', (text, target) => {
+        if (target.baseInterval.timeUnit === 'week') {
+          const start = target.tooltipDate.toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          });
+
+          let endDate = new Date(target.tooltipDate);
+          endDate.setDate(target.tooltipDate.getDate() + 6);
+          let end = endDate.toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          });
+
+          return `${start} - ${end}`;
+        }
+        return text;
+      });
 
       let feeSeries = paymentsChart.series.push(new ColumnSeries());
       feeSeries.stacked = true;


### PR DESCRIPTION
Fix #603 

* Fix incorrect dates when hovering over chart
* Remove auto week grouping to provide better picture of payout history/trend


![SCR-20220208-v8j](https://user-images.githubusercontent.com/5182324/153009602-036a44ba-e08b-4934-8bdb-3faa0d37e06d.png)
![SCR-20220208-v9b](https://user-images.githubusercontent.com/5182324/153009611-6a6fb56b-f9f3-47b6-b1a6-07a690470592.png)

![SCR-20220208-vb3](https://user-images.githubusercontent.com/5182324/153009641-77ca8732-eeb1-45a1-86f2-850426c3eb82.png)
![SCR-20220208-vct](https://user-images.githubusercontent.com/5182324/153009649-63de3a36-faf4-4a32-9e5e-9e14c4d7a50d.png)


