### PR TITLE
Fix chart disposal bug

### DIFF
--- a/src/pages/ChainStats/components/StatsChart/StatsChart.tsx
+++ b/src/pages/ChainStats/components/StatsChart/StatsChart.tsx
@@ -83,6 +83,10 @@ export const StatsChart = React.memo(
 
     useEffect(() => {
       if (data && !isFetching) {
+        if (chartRef.current) {
+          chartRef.current.dispose();
+        }
+
         chartRef.current = create('difficultyChart', XYChart);
 
         chartRef.current.colors.list = [color('#0069ff')];


### PR DESCRIPTION
Fix an issue where chart is not properlly disposed on "Network statistics".

This might introduce memory leak to end user.