### PR TITLE
Fix zoom issue for miner stats chart  

### DIFF
--- a/src/pages/MinerDashboard/Stats/MinerStats.chart.tsx
+++ b/src/pages/MinerDashboard/Stats/MinerStats.chart.tsx
@@ -206,10 +206,9 @@ export const StatsChart: React.FC<{
 
       sharesChart.cursor = new XYCursor();
       sharesChart.legend = new Legend();
-      sharesChart.legend.reverseOrder = true;
 
-      sharesChart.data = sharesData.reverse();
-      hashrateChart.data = hashrateData.reverse();
+      sharesChart.data = sharesData;
+      hashrateChart.data = hashrateData;
 
       return () => {
         hashrateChart.dispose();


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/5182324/216956405-bd4095e2-fa45-4e40-be54-5a2bbce27b80.gif)

Now:
![now](https://user-images.githubusercontent.com/5182324/216956430-5c61ffe4-fcdd-4a0b-a90f-a73897434919.gif)
