### PR TITLE
Patch/coin payout settings

### DIFF
--- a/src/pages/MinerDashboard/Settings/PayoutSettings/GasPricePercentInput/Description.tsx
+++ b/src/pages/MinerDashboard/Settings/PayoutSettings/GasPricePercentInput/Description.tsx
@@ -32,8 +32,11 @@ const Description = ({ address }: { address: string }) => {
   const activeCoinTicker = useActiveCoinTicker();
   const feeDetails = useFeePayoutLimitDetails(activeCoinTicker);
   const currencyFormatter = useLocalizedCurrencyFormatter();
-  const { data: minerDetails } = useMinerDetailsQuery({ coin: 'eth', address });
-  const { data: minerBalance } = useMinerBalance(address, 'eth');
+  const { data: minerDetails } = useMinerDetailsQuery({
+    coin: activeCoinTicker,
+    address,
+  });
+  const { data: minerBalance } = useMinerBalance(address, activeCoinTicker);
 
   const maxFeePricePercent = useMemo(
     () => Number(get(values, 'maxFeePricePercent')),


### PR DESCRIPTION
Previously, when a coin is not presented in `feePayoutLimitDetails`, for example `IRON`, Payout settings comes out blank.

This PR fixes this issue, and `maxFeePrice` will be default to 0 when submited in this situation. (The API requires this field)

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/5182324/232689706-3f0ade61-582b-4210-b623-0c0784962da5.png">
