### PR TITLE
Fix URL encoding issue

### DIFF
--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -444,8 +444,14 @@ export type AddressStatus = 'not-found' | 'pending' | 'ready';
 export async function getServerSideProps({ query, locale }) {
   var { coin, address } = query;
 
+  // This is a fix to handle IRON Memo address, e.g ADDRESS+MEMO
+  // When deployed to vercel, any "+" will be replaced with space
+  // This doesn't happen in dev.
+  // https://github.com/orgs/vercel/discussions/133#discussioncomment-3699061
+  var parsedAddress = address.replace(/ /g, '+');
+
   if (query.coin) {
-    const checkSum = getChecksumByTicker(query.coin)(query.address);
+    const checkSum = getChecksumByTicker(query.coin)(parsedAddress);
     if (checkSum === null) {
       return {
         redirect: {
@@ -454,10 +460,10 @@ export async function getServerSideProps({ query, locale }) {
         },
       };
     }
-    address = checkSum;
+    parsedAddress = checkSum;
   }
 
-  const result = await getLocateAddress(address);
+  const result = await getLocateAddress(parsedAddress);
 
   let status: AddressStatus = 'ready';
 

--- a/pages/miner/[coin]/[address].tsx
+++ b/pages/miner/[coin]/[address].tsx
@@ -482,7 +482,7 @@ export async function getServerSideProps({ query, locale }) {
         'cookie-consent',
       ])),
       coinTicker: coin,
-      address,
+      address: parsedAddress,
       status,
     },
   };


### PR DESCRIPTION
Background:
The issue is when visiting dashboard for IRON with memo, which has the address format `address+memo`, it always resolves to 404. This only happens in deployed version, not dev.

The reason for this is Vercel automatically converts `+` to space, when the request is hit to the backend.

There is no clear plan for vercel to fix this issue, read more [here](https://github.com/orgs/vercel/discussions/133#discussioncomment-3699061)

Solution:
The proposed solution is just a workaround, since our use case is simple and limited, it should be ok.